### PR TITLE
Add support for Proxmox enterprise repositories + drop deprecated Debian release support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,11 @@ proxmox_nested_virtualization: false
 # To set the Ceph Repository, proxmox_ceph_version needs to be set.
 # proxmox_ceph_version defaults to "ceph-squid".
 # proxmox_ceph_version: "ceph-squid"
+
+# If proxmox_pve_enterprise_repos is set to true, the Proxmox VE Enterprise repository will be used.
+# proxmox_pve_enterprise_repos defaults to false
+proxmox_pve_enterprise_repos: false
+
+# If proxmox_ceph_enterprise_repos is set to true, the Proxmox Ceph Enterprise repository will be used.
+# proxmox_ceph_enterprise_repos defaults to false
+proxmox_ceph_enterprise_repos: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,3 +6,5 @@
 - name: etckeeper snapshot ignore pve
   command: etckeeper commit 'ignore pve (via ansible)'
   ignore_errors: true
+- name: apt-get update
+  command: apt-get update

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,9 +6,8 @@
 #   roles:
 #     - proxmox
 #
-# Implements https://pve.proxmox.com/wiki/Install_Proxmox_VE_on_Debian_Jessie and
-# https://pve.proxmox.com/wiki/Install_Proxmox_VE_on_Debian_Stretch and
-# https://pve.proxmox.com/wiki/Install_Proxmox_VE_on_Debian_Buster
+# Implements https://pve.proxmox.com/wiki/Install_Proxmox_VE_on_Debian_12_Bookworm and
+# https://pve.proxmox.com/wiki/Install_Proxmox_VE_on_Debian_13_Trixie
 
 # On cluster creation PermitRootLogin yes is added.
 # We have to make sure that this line is removed afterwards.
@@ -19,54 +18,45 @@
     line: 'PermitRootLogin yes'
     state: absent
   notify: restart ssh
+
 - name: External IP must be resolvable in /etc/hosts
   lineinfile:
     dest: /etc/hosts
     regexp: '.*{{ ansible_fqdn }}'
     line: '{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}'
-- name: Add Proxmox VE repository key (Debian/jessie)
-  apt_key:
-    id: 9887F95A
-    url: http://download.proxmox.com/debian/key.asc
-    state: present
-  when: ansible_distribution_release == "jessie"
-- name: Add Proxmox VE repository key (Debian/stretch)
-  apt_key:
-    id: E2EF0603
-    # We can not use https to download the key, because when changing to https
-    # we end up in enterprise.proxmox.com which needs a valid subscription with
-    # username and password. *sigh*
-    url: http://download.proxmox.com/debian/proxmox-ve-release-5.x.gpg
-    keyring: /etc/apt/trusted.gpg.d/proxmox-ve-release-5.x.gpg
-    state: present
-  when: ansible_distribution_release == "stretch"
-- name: Add Proxmox VE repository key (Debian/buster)
-  apt_key:
-    id: 7BF2812E8A6E88E0
-    # We can not use https to download the key, because when changing to https
-    # we end up in enterprise.proxmox.com which needs a valid subscription with
-    # username and password. *sigh*
-    url: http://download.proxmox.com/debian/proxmox-ve-release-6.x.gpg
-    keyring: /etc/apt/trusted.gpg.d/proxmox-ve-release-6.x.gpg
-    state: present
-  when: ansible_distribution_release == "buster"
-- name: Make sure pve-enterprise is removed from apt sources
-  apt_repository:
-    repo: deb https://enterprise.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-enterprise
-    state: absent
-    update_cache: false
-- name: Enable pve-no-subscription in apt sources
-  apt_repository:
-    repo: deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription
-    filename: proxmox
-    state: present
 
-- name: Enable Ceph No-Subscription Repository
-  apt_repository:
-    repo: deb http://download.proxmox.com/debian/{{ proxmox_ceph_version|default("ceph-squid") }} {{ ansible_distribution_release }} {{ proxmox_ceph_repository|default("no-subscription") }}
-    filename: ceph
-    state: present
-  when: proxmox_ceph_enable|default(false)|bool
+# we switched from /etc/apt/sources.list.d/proxmox.list to product
+# specific files like pve.list + ceph.list
+- name: Ensure /etc/apt/sources.list.d/proxmox.list is not present
+  file:
+    dest: /etc/apt/sources.list.d/proxmox.list
+    state: absent
+  notify: apt-get update
+
+# we manage the repository ourselves
+- name: Remove /etc/apt/sources.list.d/pve-enterprise.list (if installed by Proxmox)
+  file:
+    dest: /etc/apt/sources.list.d/pve-enterprise.list
+    state: absent
+  notify: apt-get update
+
+- name: Deploy Proxmox VE apt repository
+  template:
+    src: templates/apt/pve.list.j2
+    dest: /etc/apt/sources.list.d/pve.list
+    owner: root
+    group: root
+    mode: 0644
+  notify: apt-get update
+
+- name: Deploy Proxmox Ceph apt repository
+  template:
+    src: templates/apt/ceph.list.j2
+    dest: /etc/apt/sources.list.d/ceph.list
+    owner: root
+    group: root
+    mode: 0644
+  notify: apt-get update
 
 - name: Make sure a conflicting firmware-amd-graphics package is purged
   apt:
@@ -82,13 +72,6 @@
     state: present
   when: not ansible_check_mode
 
-- name: Remove /etc/apt/sources.list.d/pve-enterprise.list (if installed by Proxmox)
-  file: dest=/etc/apt/sources.list.d/pve-enterprise.list state=absent
-- name: Install systemd-sysv (if Debian/jessie)
-  apt:
-    name: systemd-sysv
-    state: present
-  when: ansible_distribution_release == "jessie"
 - name: Check for etckeeper
   shell: 'dpkg -l etckeeper | grep -e "^ii" -q'
   register: etckeeper_installed

--- a/templates/apt/ceph.list.j2
+++ b/templates/apt/ceph.list.j2
@@ -1,0 +1,6 @@
+# HEADER: managed by ansible, do NOT edit manually!
+{% if proxmox_ceph_enterprise_repos %}
+deb https://enterprise.proxmox.com/debian/{{ proxmox_ceph_version|default("ceph-squid") }} {{ ansible_distribution_release }} enterprise
+{% else %}
+deb http://download.proxmox.com/debian/{{ proxmox_ceph_version|default("ceph-squid") }} {{ ansible_distribution_release }} {{ proxmox_ceph_repository|default("no-subscription") }}
+{% endif %}

--- a/templates/apt/pve.list.j2
+++ b/templates/apt/pve.list.j2
@@ -1,0 +1,6 @@
+# HEADER: managed by ansible, do NOT edit manually!
+{% if proxmox_pve_enterprise_repos %}
+deb https://enterprise.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-enterprise
+{% else %}
+deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription
+{% endif %}


### PR DESCRIPTION
Relevant changes:

* Support Proxmox enterprise repositories, by setting `proxmox_pve_enterprise_repos: true` (for PVE) + `proxmox_ceph_enterprise_repos: true` (for Ceph)

* No longer deploy Proxmox repositories to /etc/apt/sources.list.d/proxmox.list, but use product specific files instead.

  We need to support all the PVE, Ceph + PBS repositories from Proxmox, while we can't easily control all those from within different roles (jkirk.proxmox + jkirk.proxmox_pbs) at the same time.  Instead use templates, to use pve.list for the PVE repository and ceph.list for the Ceph one, without running into conflicts and being able to control enterprise vs. no-subscription usage for each of them.

* Update comment regarding PVE installation on Debian (drop jessie, stretch and buster ones, add currently supported bookworm + trixie instead)

* Drop support for jessie, stretch + buster, which all are no longer supported by upstream since ages