### PR TITLE
Remove Proxmox Ceph apt repository

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,13 @@
     mode: 0644
   notify: apt-get update
 
+- name: Remove Proxmox Ceph apt repository
+  file:
+    path: /etc/apt/sources.list.d/ceph.list
+    state: absent
+  notify: apt-get update
+  when: not proxmox_ceph_enable|default(false)|bool
+
 - name: Deploy Proxmox Ceph apt repository
   template:
     src: templates/apt/ceph.list.j2


### PR DESCRIPTION
Remove Proxmox Ceph apt repository if proxmox_ceph_enable is false (which is the default).

This is a followup of c5591be + c0c36d3.