### PR TITLE
do not enable PVE repository on Debian 10 and older

### DIFF
--- a/templates/apt/pve.list.j2
+++ b/templates/apt/pve.list.j2
@@ -1,6 +1,10 @@
 # HEADER: managed by ansible, do NOT edit manually!
+{% if ansible_distribution_major_version | int > 10 %}
 {% if proxmox_pve_enterprise_repos %}
 deb https://enterprise.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-enterprise
 {% else %}
 deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription
+{% endif %}
+{% else %}
+# Debian release {{ ansible_distribution_major_version }} is EOL, skipping pve repository setup
 {% endif %}


### PR DESCRIPTION
@mika I think your downstream change is useful upstream too, or?

> Debian 10 AKA buster is EOL since 2022-09-10 and its LTS is also EOL since 2024-06-30, the pve repository no longer exists and fails with 404 errors.